### PR TITLE
func handleRequest() recv_obj has no data problem

### DIFF
--- a/httpbase/qasynhttpsocket.cpp
+++ b/httpbase/qasynhttpsocket.cpp
@@ -227,13 +227,16 @@ int QAsynHttpSocket::doMessageComplete(http_parser *parser)
     request->m_remoteAddress = theConnection->peerAddress().toString();
     request->m_remotePort = theConnection->peerPort();
 
+    // append data
+    request->appendBody(theConnection->m_currentBody);
 
     qDebug() << "QHttpResponse:new,ThreadId:"<<QThread::currentThreadId()  ;
     QHttpResponse *response = new QHttpResponse(theConnection);
     if (parser->http_major < 1 || parser->http_minor < 1)
         response->m_keepAlive = false;
 
-    request->storeBody();
+//    request->storeBody();
+//    emit request->data(theConnection->m_currentBody);
     request->setSuccessful(true);
 
     Q_EMIT theConnection->newRequest(request, response);

--- a/httpbase/qhttpserver.cpp
+++ b/httpbase/qhttpserver.cpp
@@ -112,8 +112,11 @@ void QHttpServer::handleRequest(QHttpRequest *req, QHttpResponse *resp)
         return ;
     }
 
-    QJsonDocument doc=QJsonDocument::fromBinaryData(req->body());
-    QJsonObject recv_obj=doc.object();//这是接收到的json对象
+//    QJsonDocument doc=QJsonDocument::fromBinaryData(req->body());
+    QJsonParseError myerr;
+    QJsonDocument doc = QJsonDocument::fromJson(req->body(), &myerr);
+    QJsonObject recv_obj = doc.object();//这是接收到的json对象
+    emit updateRecvInfoSlot(recv_obj);
 
     QConnectPool* dbpool=QMultiDbManager::getDb("sql2014");
     if(dbpool!=NULL)

--- a/httpbase/qhttpserver.h
+++ b/httpbase/qhttpserver.h
@@ -31,6 +31,10 @@ public:
     QString searchConfigFile();
 
     QMultiDbManager m_mdbmng;
+
+signals:
+    void updateRecvInfoSlot(QJsonObject recv_obj);
+
 private Q_SLOTS:
     void handleRequest(QHttpRequest *request, QHttpResponse *response);
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -69,7 +69,7 @@ void MainWindow::on_pbStart_clicked()
     qDebug() << "MainWindow:on_pbStart_clicked,ThreadId:"<<QThread::currentThreadId()  ;
 
     QHttpServer *server = new QHttpServer(this);
-
+    connect(server, &QHttpServer::updateRecvInfoSlot, this, &MainWindow::updateRecvInfoSlot);
     if(server->listen(QHostAddress::Any, qint16(ui->lePort->text().toInt())))
     {
         ui->teLog->append("http 服务已经启动!");
@@ -79,3 +79,16 @@ void MainWindow::on_pbStart_clicked()
     }
 }
 
+void MainWindow::updateRecvInfoSlot(QJsonObject recv_obj)
+{
+    QJsonObject *prm = reinterpret_cast<QJsonObject *>(&recv_obj);
+    QJsonObject::const_iterator it = prm->constBegin();
+    QJsonObject::const_iterator end = prm->constEnd();
+
+    while (it != end)
+    {
+        ui->teLog->append(it.key());
+        ui->teLog->append(it.value().toVariant().toString());
+        it++;
+    }
+}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -19,6 +19,9 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
+public slots:
+    void updateRecvInfoSlot(QJsonObject recv_obj);
+
 private slots:
     void on_pbStart_clicked();
 private:


### PR DESCRIPTION
update QHttpServer::handleRequest(QHttpRequest *req, QHttpResponse *resp) function, the req->body() is empty problem.
Added the function that data is sent to MainWindow through singal { QHttpServer::updateRecvInfoSlot(QJsonObject recv_obj) }  and displayed in ui->teLog;